### PR TITLE
Bump byteorder dep to v0.4.2.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ exclude = [
 ]
 
 [dependencies]
-byteorder = "0.3.13"
+byteorder = "0.4.2"


### PR DESCRIPTION
Cargo doesn't consider 0.4 compatible with 0.3 although the API
is in fact backward-compatible. Might as well update to the latest
release so mp4parse doesn't have to compile two different versions.
