### PR TITLE
Modernize a bit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "test-assembler"
 description = "A set of types for building complex binary streams."
+edition = "2021"
 version = "0.1.7-alpha.0"
 authors = ["Ted Mielczarek <ted@mielczarek.org>"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ You use this crate primarily by creating a `Section`, which provides APIs to bui
   let l1 = Label::new();
   let l2 = Label::new();
   // `Section`s have an associated default endianness.
-  let s = Section::with_endian(Endian::Little);
+  let mut s = Section::with_endian(Endian::Little);
   // `start` is a `Label` whose value is the beginning of the `Section`'s data.
   let start = s.start();
-  let s = s.append_bytes(&[0x01, 0x02, 0x03])
+  s.append_bytes(&[0x01, 0x02, 0x03])
     // Append a 32-bit word with the section's default endianness
     // Methods on `Section` chain to make writing repeated entries simple!
     .D32(0xabcd0102)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,24 +78,19 @@
 //! ```
 
 #![allow(non_snake_case)]
-
-extern crate byteorder;
-
-#[cfg(doctest)]
-extern crate doc_comment;
+#![warn(rust_2018_idioms)]
 
 #[cfg(doctest)]
 doc_comment::doctest!("../README.md");
 
-use std::borrow::Borrow;
-use std::cell::RefCell;
-use std::fmt;
-use std::io::Cursor;
-use std::io::Seek;
-use std::io::SeekFrom;
-use std::io::Write;
-use std::ops::{Add, Deref, Sub};
-use std::rc::Rc;
+use std::{
+    borrow::Borrow,
+    cell::RefCell,
+    fmt,
+    io::{Cursor, Seek, SeekFrom, Write},
+    ops::{Add, Deref, Sub},
+    rc::Rc,
+};
 
 use byteorder::{BigEndian, LittleEndian, WriteBytesExt};
 
@@ -125,7 +120,7 @@ enum BindingValue {
 }
 
 impl fmt::Debug for BindingValue {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             BindingValue::Constant(v) => write!(f, "Constant({})", v),
             BindingValue::From(ref b, v) => write!(f, "From({:?}, {})", b, v),
@@ -140,7 +135,7 @@ struct Binding {
 }
 
 impl fmt::Debug for Binding {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Binding {{ {:?} }}", self.value.borrow())
     }
 }
@@ -233,7 +228,7 @@ pub struct RealLabel {
 }
 
 impl fmt::Debug for RealLabel {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}", self.binding)
     }
 }
@@ -336,7 +331,7 @@ impl LabelMaker for RealLabel {
 pub struct Label(pub Rc<RealLabel>);
 
 impl fmt::Debug for Label {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Label {{ {:?} }}", self.0)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -339,26 +339,26 @@ impl fmt::Debug for Label {
 impl Deref for Label {
     type Target = RealLabel;
 
-    fn deref(&self) -> &RealLabel {
+    fn deref(&self) -> &Self::Target {
         let &Label(ref inner) = self;
         inner.deref()
     }
 }
 
 impl LabelMaker for Label {
-    fn new() -> Label {
-        Label(Rc::new(RealLabel::new()))
+    fn new() -> Self {
+        Self(Rc::new(RealLabel::new()))
     }
-    fn from_const(val: u64) -> Label {
-        Label(Rc::new(RealLabel::from_const(val)))
+    fn from_const(val: u64) -> Self {
+        Self(Rc::new(RealLabel::from_const(val)))
     }
-    fn from_label(other: &Label) -> Label {
-        let &Label(ref inner) = other;
+    fn from_label(other: &Self) -> Self {
+        let &Self(ref inner) = other;
         Label(Rc::new(RealLabel::from_label(inner.borrow())))
     }
-    fn from_label_offset(other: &Label, offset: i64) -> Label {
-        let &Label(ref inner) = other;
-        Label(Rc::new(RealLabel::from_label_offset(
+    fn from_label_offset(other: &Self, offset: i64) -> Self {
+        let &Self(ref inner) = other;
+        Self(Rc::new(RealLabel::from_label_offset(
             inner.borrow(),
             offset,
         )))
@@ -393,7 +393,7 @@ impl<'a> Sub<i64> for &'a Label {
 impl<'a> Sub<&'a Label> for &'a Label {
     type Output = i64;
 
-    fn sub(self, rhs: &'a Label) -> i64 {
+    fn sub(self, rhs: Self) -> i64 {
         self.offset(rhs).unwrap()
     }
 }
@@ -504,7 +504,7 @@ impl Section {
         }
     }
 
-    /// Constructs a `Section` via a user supplied for simpler one-liners
+    /// Constructs a `Section` via a user-supplied closure for simpler one-liners
     pub fn inline(endian: Option<Endian>, func: impl FnOnce(&mut Self) -> &mut Self) -> Self {
         let mut this = Self::with_endian(endian.unwrap_or(DEFAULT_ENDIAN));
 
@@ -684,7 +684,7 @@ impl Section {
     ///
     /// `byte` may be a `Label` or a `u8`.
     /// Return this section.
-    pub fn D8<'a, T: ToLabelOrNum<'a, u8>>(&mut self, byte: T) -> &mut Self {
+    pub fn D8<'a>(&mut self, byte: impl ToLabelOrNum<'a, u8>) -> &mut Self {
         let endian = self.endian;
         match byte.to_labelornum() {
             LabelOrNum::Num(n) => {
@@ -697,13 +697,13 @@ impl Section {
     /// Append `byte` as little-endian (identical to `D8`).
     ///
     /// Return this section.
-    pub fn L8<'a, T: ToLabelOrNum<'a, u8>>(&mut self, byte: T) -> &mut Self {
+    pub fn L8<'a>(&mut self, byte: impl ToLabelOrNum<'a, u8>) -> &mut Self {
         self.D8(byte)
     }
     /// Append `byte` as big-endian (identical to `D8`).
     ///
     /// Return this section.
-    pub fn B8<'a, T: ToLabelOrNum<'a, u8>>(&mut self, byte: T) -> &mut Self {
+    pub fn B8<'a>(&mut self, byte: impl ToLabelOrNum<'a, u8>) -> &mut Self {
         self.D8(byte)
     }
 
@@ -711,7 +711,7 @@ impl Section {
     ///
     /// `word` may be a `Label` or a `u16`.
     /// Return this section.
-    pub fn D16<'a, T: ToLabelOrNum<'a, u16>>(&mut self, word: T) -> &mut Self {
+    pub fn D16<'a>(&mut self, word: impl ToLabelOrNum<'a, u16>) -> &mut Self {
         match self.endian {
             Endian::Little => self.L16(word),
             Endian::Big => self.B16(word),
@@ -721,7 +721,7 @@ impl Section {
     ///
     /// `word` may be a `Label` or a `u16`.
     /// Return this section.
-    pub fn L16<'a, T: ToLabelOrNum<'a, u16>>(&mut self, word: T) -> &mut Self {
+    pub fn L16<'a>(&mut self, word: impl ToLabelOrNum<'a, u16>) -> &mut Self {
         match word.to_labelornum() {
             LabelOrNum::Num(n) => {
                 self.contents.write_u16::<LittleEndian>(n).unwrap();
@@ -734,7 +734,7 @@ impl Section {
     ///
     /// `word` may be a `Label` or a `u16`.
     /// Return this section.
-    pub fn B16<'a, T: ToLabelOrNum<'a, u16>>(&mut self, word: T) -> &mut Self {
+    pub fn B16<'a>(&mut self, word: impl ToLabelOrNum<'a, u16>) -> &mut Self {
         match word.to_labelornum() {
             LabelOrNum::Num(n) => {
                 self.contents.write_u16::<BigEndian>(n).unwrap();
@@ -748,7 +748,7 @@ impl Section {
     ///
     /// `dword` may be a `Label` or a `u32`.
     /// Return this section.
-    pub fn D32<'a, T: ToLabelOrNum<'a, u32>>(&mut self, dword: T) -> &mut Self {
+    pub fn D32<'a>(&mut self, dword: impl ToLabelOrNum<'a, u32>) -> &mut Self {
         match self.endian {
             Endian::Little => self.L32(dword),
             Endian::Big => self.B32(dword),
@@ -758,7 +758,7 @@ impl Section {
     ///
     /// `dword` may be a `Label` or a `u32`.
     /// Return this section.
-    pub fn L32<'a, T: ToLabelOrNum<'a, u32>>(&mut self, dword: T) -> &mut Self {
+    pub fn L32<'a>(&mut self, dword: impl ToLabelOrNum<'a, u32>) -> &mut Self {
         match dword.to_labelornum() {
             LabelOrNum::Num(n) => {
                 self.contents.write_u32::<LittleEndian>(n).unwrap();
@@ -771,7 +771,7 @@ impl Section {
     ///
     /// `dword` may be a `Label` or a `u32`.
     /// Return this section.
-    pub fn B32<'a, T: ToLabelOrNum<'a, u32>>(&mut self, dword: T) -> &mut Self {
+    pub fn B32<'a>(&mut self, dword: impl ToLabelOrNum<'a, u32>) -> &mut Self {
         match dword.to_labelornum() {
             LabelOrNum::Num(n) => {
                 self.contents.write_u32::<BigEndian>(n).unwrap();
@@ -785,7 +785,7 @@ impl Section {
     ///
     /// `qword` may be a `Label` or a `u32`.
     /// Return this section.
-    pub fn D64<'a, T: ToLabelOrNum<'a, u64>>(&mut self, qword: T) -> &mut Self {
+    pub fn D64<'a>(&mut self, qword: impl ToLabelOrNum<'a, u64>) -> &mut Self {
         match self.endian {
             Endian::Little => self.L64(qword),
             Endian::Big => self.B64(qword),
@@ -795,7 +795,7 @@ impl Section {
     ///
     /// `qword` may be a `Label` or a `u32`.
     /// Return this section.
-    pub fn L64<'a, T: ToLabelOrNum<'a, u64>>(&mut self, qword: T) -> &mut Self {
+    pub fn L64<'a>(&mut self, qword: impl ToLabelOrNum<'a, u64>) -> &mut Self {
         match qword.to_labelornum() {
             LabelOrNum::Num(n) => {
                 self.contents.write_u64::<LittleEndian>(n).unwrap();
@@ -808,7 +808,7 @@ impl Section {
     ///
     /// `qword` may be a `Label` or a `u32`.
     /// Return this section.
-    pub fn B64<'a, T: ToLabelOrNum<'a, u64>>(&mut self, qword: T) -> &mut Self {
+    pub fn B64<'a>(&mut self, qword: impl ToLabelOrNum<'a, u64>) -> &mut Self {
         match qword.to_labelornum() {
             LabelOrNum::Num(n) => {
                 self.contents.write_u64::<BigEndian>(n).unwrap();


### PR DESCRIPTION
I don't think this fully finishes #12, but I figured I would open this PR now to get feedback before doing even more changes.

This updates to the 2021 edition and fixes up a bit around that change, though I've only enabled a single lint `rust_2018_idioms` (doesn't look like there is a 2021 version) for now, but adding more lints that aren't in the default clippy set will most likely expose more.

This also moves all of the unit tests into a `#[cfg(test)]` module to avoid compiling them in downstream crates.

The biggest change from an API perspective is just converting all of the `self` methods on `Section`, other than `get_contents`, to be `&mut Self` instead. For simple usage like in the unit tests and examples, this makes the API slightly more cumbersome, though I've added a `Section::inline` that mitigates this somewhat to allow a simple closure to be used to construct a `Section`, I think for more complex use cases this improves the API and makes it nicer to use from external code.

Part of: #12 